### PR TITLE
fix: remove slash from module reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In case there is not OpenID Connect provider already created in the AWS account,
 
 ```hcl
 module "oidc_provider" {
-  source = "github.com/philips-labs/terraform-aws-github-oidc/?ref=<version>//modules/provider"
+  source = "github.com/philips-labs/terraform-aws-github-oidc?ref=<version>//modules/provider"
 }
 ```
 


### PR DESCRIPTION
I was getting the following error and this fix worked for me.

```
Initializing modules...
Downloading git::https://github.com/philips-labs/terraform-aws-github-oidc.git for oidc_provider...
╷
│ Error: subdir "%253Fref=v0.6.0/modules/provider" not found
│
│
╵

╷
│ Error: subdir "%253Fref=v0.6.0/modules/provider" not found
│
│
```