### PR TITLE
feat: Add github_oidc_issuer variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,20 +62,19 @@ module "oidc_repo_s3" {
 Check out the [example](examples/default/README.md) for a full example of using the module.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Requirements
 
-| Name                                                                     | Version |
-| ------------------------------------------------------------------------ | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1    |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 3    |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3 |
 
 ## Providers
 
-| Name                                                      | Version |
-| --------------------------------------------------------- | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws)          | >= 3    |
-| <a name="provider_random"></a> [random](#provider_random) | n/a     |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -83,37 +82,37 @@ No modules.
 
 ## Resources
 
-| Name                                                                                                                                                            | Type        |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_iam_role.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                                                       | resource    |
-| [aws_iam_role_policy_attachment.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)                 | resource    |
-| [random_string.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)                                                   | resource    |
+| Name | Type |
+|------|------|
+| [aws_iam_role.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [random_string.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_iam_policy_document.github_actions_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
-| Name                                                                                                               | Description                                                                                                                                               | Type                                                                                               | Default                                                     | Required |
-| ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | :------: |
-| <a name="input_account_ids"></a> [account_ids](#input_account_ids)                                                 | Root users of these Accounts (id) would be given the permissions to assume the role created by this module.                                               | `list(string)`                                                                                     | `[]`                                                        |    no    |
-| <a name="input_custom_principal_arns"></a> [custom_principal_arns](#input_custom_principal_arns)                   | List of IAM principals ARNs able to assume the role created by this module.                                                                               | `list(string)`                                                                                     | `[]`                                                        |    no    |
-| <a name="input_conditions"></a> [conditions](#input_conditions)                                                    | (Optional) Additonal conditions for checking the OIDC claim.                                                                                              | <pre>list(object({<br> test = string<br> variable = string<br> values = list(string)<br> }))</pre> | `[]`                                                        |    no    |
-| <a name="input_default_conditions"></a> [default_conditions](#input_default_conditions)                            | (Optional) Default condtions to apply, at least one of the following is madatory: 'allow_main', 'allow_environment', 'deny_pull_request' and 'allow_all'. | `list(string)`                                                                                     | <pre>[<br> "allow_main",<br> "deny_pull_request"<br>]</pre> |    no    |
-| <a name="input_github_environments"></a> [github_environments](#input_github_environments)                         | (Optional) Allow GitHub action to deploy to all (default) or to one of the environments in the list.                                                      | `list(string)`                                                                                     | <pre>[<br> "*"<br>]</pre>                                   |    no    |
-| <a name="input_openid_connect_provider_arn"></a> [openid_connect_provider_arn](#input_openid_connect_provider_arn) | Set the openid connect provider ARN when the provider is not managed by the module.                                                                       | `string`                                                                                           | n/a                                                         |   yes    |
-| <a name="input_repo"></a> [repo](#input_repo)                                                                      | (Optional) GitHub repository to grant access to assume a role via OIDC. When the repo is set, a role will be created.                                     | `string`                                                                                           | `null`                                                      |    no    |
-| <a name="input_role_max_session_duration"></a> [role_max_session_duration](#input_role_max_session_duration)       | Maximum session duration (in seconds) that you want to set for the specified role.                                                                        | `number`                                                                                           | `null`                                                      |    no    |
-| <a name="input_role_name"></a> [role_name](#input_role_name)                                                       | (Optional) role name of the created role, if not provided the `namespace` will be used.                                                                   | `string`                                                                                           | `null`                                                      |    no    |
-| <a name="input_role_path"></a> [role_path](#input_role_path)                                                       | (Optional) Path for the created role, requires `repo` is set.                                                                                             | `string`                                                                                           | `"/github-actions/"`                                        |    no    |
-| <a name="input_role_permissions_boundary"></a> [role_permissions_boundary](#input_role_permissions_boundary)       | (Optional) Boundary for the created role, requires `repo` is set.                                                                                         | `string`                                                                                           | `null`                                                      |    no    |
-| <a name="input_role_policy_arns"></a> [role_policy_arns](#input_role_policy_arns)                                  | List of ARNs of IAM policies to attach to IAM role                                                                                                        | `list(string)`                                                                                     | `[]`                                                        |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | Root users of these Accounts (id) would be given the permissions to assume the role created by this module. | `list(string)` | `[]` | no |
+| <a name="input_conditions"></a> [conditions](#input\_conditions) | (Optional) Additonal conditions for checking the OIDC claim. | <pre>list(object({<br>    test     = string<br>    variable = string<br>    values   = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_custom_principal_arns"></a> [custom\_principal\_arns](#input\_custom\_principal\_arns) | List of IAM principals ARNs able to assume the role created by this module. | `list(string)` | `[]` | no |
+| <a name="input_default_conditions"></a> [default\_conditions](#input\_default\_conditions) | (Optional) Default condtions to apply, at least one of the following is madatory: 'allow\_main', 'allow\_environment', 'deny\_pull\_request' and 'allow\_all'. | `list(string)` | <pre>[<br>  "allow_main",<br>  "deny_pull_request"<br>]</pre> | no |
+| <a name="input_github_environments"></a> [github\_environments](#input\_github\_environments) | (Optional) Allow GitHub action to deploy to all (default) or to one of the environments in the list. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_github_oidc_issuer"></a> [github\_oidc\_issuer](#input\_github\_oidc\_issuer) | OIDC issuer for GitHub Actions | `string` | `"token.actions.githubusercontent.com"` | no |
+| <a name="input_openid_connect_provider_arn"></a> [openid\_connect\_provider\_arn](#input\_openid\_connect\_provider\_arn) | Set the openid connect provider ARN when the provider is not managed by the module. | `string` | n/a | yes |
+| <a name="input_repo"></a> [repo](#input\_repo) | (Optional) GitHub repository to grant access to assume a role via OIDC. When the repo is set, a role will be created. | `string` | `null` | no |
+| <a name="input_role_max_session_duration"></a> [role\_max\_session\_duration](#input\_role\_max\_session\_duration) | Maximum session duration (in seconds) that you want to set for the specified role. | `number` | `null` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | (Optional) role name of the created role, if not provided the `namespace` will be used. | `string` | `null` | no |
+| <a name="input_role_path"></a> [role\_path](#input\_role\_path) | (Optional) Path for the created role, requires `repo` is set. | `string` | `"/github-actions/"` | no |
+| <a name="input_role_permissions_boundary"></a> [role\_permissions\_boundary](#input\_role\_permissions\_boundary) | (Optional) Boundary for the created role, requires `repo` is set. | `string` | `null` | no |
+| <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | List of ARNs of IAM policies to attach to IAM role | `list(string)` | `[]` | no |
 
 ## Outputs
 
-| Name                                                              | Description                                                        |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------ |
-| <a name="output_conditions"></a> [conditions](#output_conditions) | The assume conditions added to the role.                           |
-| <a name="output_role"></a> [role](#output_role)                   | The crated role that can be assumed for the configured repository. |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_conditions"></a> [conditions](#output\_conditions) | The assume conditions added to the role. |
+| <a name="output_role"></a> [role](#output\_role) | The crated role that can be assumed for the configured repository. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Contribution

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
   github_environments = (length(var.github_environments) > 0 && var.repo != null) ? [for e in var.github_environments : "repo:${var.repo}:environment:${e}"] : ["ensurethereisnotmatch"]
   role_name           = (var.repo != null && var.role_name != null) ? var.role_name : "${substr(replace(var.repo != null ? var.repo : "", "/", "-"), 0, 64 - 8)}-${random_string.random[0].id}"
 
-  variable_sub = "token.actions.githubusercontent.com:sub"
+  variable_sub = "${var.github_oidc_issuer}:sub"
 
   default_allow_main = contains(var.default_conditions, "allow_main") ? [{
     test     = "StringLike"
@@ -73,7 +73,7 @@ data "aws_iam_policy_document" "github_actions_assume_role_policy" {
 
     condition {
       test     = "StringEquals"
-      variable = "token.actions.githubusercontent.com:aud"
+      variable = "${var.github_oidc_issuer}:aud"
       values   = ["sts.amazonaws.com"]
     }
 

--- a/variables.tf
+++ b/variables.tf
@@ -88,3 +88,9 @@ variable "custom_principal_arns" {
   type        = list(string)
   default     = []
 }
+
+variable "github_oidc_issuer" {
+  description = "OIDC issuer for GitHub Actions"
+  type        = string
+  default     = "token.actions.githubusercontent.com"
+}


### PR DESCRIPTION
As per [GitHub OpenID security hardening guide](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-token-url-for-an-enterprise) it's now possible to change the OpenID issuer of Github actions.

This adds a `github_oidc_issuer` variable to allow configuring it.

Fixes #66 