### PR TITLE
feat: Add repo_mainline_branch variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ locals {
   default_allow_main = contains(var.default_conditions, "allow_main") ? [{
     test     = "StringLike"
     variable = local.variable_sub
-    values   = ["repo:${var.repo}:ref:refs/heads/main"]
+    values   = ["repo:${var.repo}:ref:refs/heads/${var.repo_mainline_branch}"]
   }] : []
 
   default_allow_environment = contains(var.default_conditions, "allow_environment") ? [{

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "repo" {
   }
 }
 
+variable "repo_mainline_branch" {
+  description = "(Optional) Mainline branch of the GitHub repository, defaults to 'main'. This will be the main/default branch that `allow_main` provides access to."
+  type        = string
+  default     = "main"
+}
+
 variable "role_name" {
   description = "(Optional) role name of the created role, if not provided the `namespace` will be used."
   type        = string


### PR DESCRIPTION
Hello!

This PR adds a simple change/variable, that adds support for mainline branches that *are not* `main` (for example: `master`).

This is necessary for some users, as `default_conditions` requires *at least* one condition to be provided.  `allow_main` makes the most sense to most likely be that default, but *only* if the mainline branch is actually `main`.

This adds in that ability to support.

Thanks!