### PR TITLE
update default thumbprints

### DIFF
--- a/modules/provider/variables.tf
+++ b/modules/provider/variables.tf
@@ -1,9 +1,12 @@
 ##
-## Thumbprint published by GitHub https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/
+## Thumbprints published by GitHub https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
 ## can also be generated with the script in ./bin/generate-thumbprint.sh
 ##
 variable "thumbprint_list" {
   description = "(Optional) A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s)."
   type        = list(string)
-  default     = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+  default     = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
+  ]
 }


### PR DESCRIPTION
GitHub now requires that one of certificates must be trusted: https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws

See also https://github.com/aws-actions/configure-aws-credentials/issues/357