### PR TITLE
feat: Adding tags variable to the aws_iam_openid_connect_provider resource

### DIFF
--- a/modules/provider/main.tf
+++ b/modules/provider/main.tf
@@ -2,4 +2,5 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
   url             = "https://token.actions.githubusercontent.com"
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = var.thumbprint_list
+  tags            = var.tags
 }

--- a/modules/provider/variables.tf
+++ b/modules/provider/variables.tf
@@ -10,3 +10,8 @@ variable "thumbprint_list" {
     "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
   ]
 }
+
+variable "tags" {
+  description = "(Optional) Map of resource tags for the IAM OIDC provider. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level."
+  type = map(string)
+}


### PR DESCRIPTION
As we create resources is always a good practice to keep tags for them. This PR adds the [tags argument](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider#tags) to the aws_iam_openid_connect_provider resource which reads its value from the `tags` variables.