### PR TITLE
docs: Updated readme to include details of permissions required in workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ The module creates a role with an assume role policy to check the OIDC claims fo
 - `deny_pull_request`: Denies assuming the role for a pull request.
 - `allow_all` : Allow GitHub Actions for any claim for the repository. Be careful, this allows forks as well to assume the role!
 
+## Required GitHub Workflows Permissions
+
+When configuring GitHub workflows to use this module, you need to specify the following permissions in your workflow configuration:
+
+```yaml
+permissions:
+  id-token: write
+```
+
+This permission is required for the GitHub Actions to be able to assume the IAM role created by this module.
+
 ## Usages
 
 In case there is not OpenID Connect provider already created in the AWS account, create one via the submodule.

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -18,3 +18,14 @@ terraform apply
 For the S3 repository follow the directions in the single example. On the console the name of the ECR repo and role are printed. Next update [workflow](../repositories/.github/workflows/../../repo-ecr/.github/workflows/ecr.yml) for the repo and role. Add, commit and push. The job should now push a busybox container to your ECR repo.
 
 Finally you can clean up with `terraform destroy`
+
+## Required GitHub Workflows Permissions
+
+When configuring GitHub workflows to use this module, you need to specify the following permissions in your workflow configuration:
+
+```yaml
+permissions:
+  id-token: write
+```
+
+This permission is required for the GitHub Actions to be able to assume the IAM role created by this module.


### PR DESCRIPTION
This pull request includes updates to the documentation to specify the required GitHub Workflows permissions for using this module. The most important changes are the additions to the `README.md` and `examples/default/README.md` files.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R37): Added a section detailing the required GitHub Workflows permissions, specifically the `id-token: write` permission, which is necessary for GitHub Actions to assume the IAM role created by the module.
* [`examples/default/README.md`](diffhunk://#diff-b8070e0a1862abede19528a69836030b9dab53ca7368268f3084e15dfdffa25cR21-R31): Added a similar section on required GitHub Workflows permissions, ensuring users configure their workflows correctly to assume the IAM role.